### PR TITLE
修复转义字符的问题

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ module.exports = function(content, file, conf) {
 
   cssContent = cssContent.replace(/[\n|\r]/g, " ");
   cssContent = cssContent.replace(/'/g, '\"');
+  cssContent = cssContent.replace(/\\/g, "\\\\");
   cssContent = "'" + cssContent + "'";
 
   var injectCssFn = tinytim.render(conf.templates.css_injector, {});


### PR DESCRIPTION
遇到有css hack等情况需要转义\;
例如: filter: none\9;
